### PR TITLE
 CT-7601: return permission from os to webview

### DIFF
--- a/src/ios/CDVWKWebViewUIDelegate.m
+++ b/src/ios/CDVWKWebViewUIDelegate.m
@@ -120,4 +120,12 @@
     [rootController presentViewController:alert animated:YES completion:nil];
 }
 
+- (void) webView:(WKWebView*)webView 
+    requestMediaCapturePermissionForOrigin:(nonnull WKSecurityOrigin *)origin 
+    initiatedByFrame:(nonnull WKFrameInfo *)frame 
+    type:(WKMediaCaptureType)type decisionHandler:(nonnull void (^)(WKPermissionDecision))decisionHandler
+    API_AVAILABLE(ios(15.0))
+{
+    decisionHandler(WKPermissionDecisionGrant);
+}
 @end


### PR DESCRIPTION
#### Problem Statement
The app repeatly request camera permission even the permission is granted after relaunch app.

#### Root Cause
A customization in [APC-6061](https://track.appspace.com/browse/APC-6061) that previously made is overriden after moving the source of the plugin into Github.

#### Fix
Added the customization back to src/ios/CDVWKWebViewUIDelegate.m

#### Impacted area
iOS app